### PR TITLE
踏み台サーバ用のロールを作成

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,2 +1,5 @@
 [nas]
  192.168.11.152 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/mfmf.pem
+
+[springboard]
+  18.179.4.232 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/mfmf.pem

--- a/service/springboard/main.yml
+++ b/service/springboard/main.yml
@@ -1,0 +1,15 @@
+
+---
+- hosts: springboard
+
+  vars:
+    host_name: "springboard"
+  roles:
+    - ../core
+  tasks:
+    - name: apt installs
+      apt:
+        name:
+          - ansible
+          - git
+        update_cache: true


### PR DESCRIPTION
極力インスタンスにパブリックIPは振りたくないのと、ローカルからだとansibleの実行が遅いので踏み台経由でインスタンス操作を行う運用にしたいので踏み台サーバを構築